### PR TITLE
Set repeated packet TTL to 255.

### DIFF
--- a/mdns-repeater.c
+++ b/mdns-repeater.c
@@ -186,6 +186,12 @@ static int create_send_sock(int recv_sockfd, const char *ifname, struct if_sock 
 		return r;
 	}
 
+    int ttl = 255; // IP TTL should be 255: https://datatracker.ietf.org/doc/html/rfc6762#section-11
+    if ((r = setsockopt(sd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl))) < 0) {
+        log_message(LOG_ERR, "send setsockopt(IP_MULTICAST_TTL): %m");
+        return r;
+    }
+
 	char *addr_str = strdup(inet_ntoa(sockdata->addr));
 	char *mask_str = strdup(inet_ntoa(sockdata->mask));
 	char *net_str  = strdup(inet_ntoa(sockdata->net));


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6762#section-11

There's some more detail in https://github.com/kennylevinsen/mdns-repeater/issues/10, but the TL; DR is that some mDNS clients are impemented to only accept packets with an IP TTL of 255 since there was an early draft of the RFC that had that requirement. The current RFC says all mDNS packets should be sent with IP TTL of 255 to accommodate those clients.